### PR TITLE
Allow RS256 to sign JWT tokens, including backchannel

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ openssl rsa -pubout -in private_key.pem -out public_key.pem
       ui_locales: "en", # comma-separated; can also include `cy` for Welsh UI
       vtr: ["Cl.Cm"], # array with one element; dot-separated; can also include identity vectors such as `P2` (eg. `Cl.Cm.P2`)
       pkce: false, # set to `true` to enable "Proof Key for Code Exchange"
-      userinfo_claims: [] # array of URLs; see https://docs.sign-in.service.gov.uk/integrate-with-integration-environment/authenticate-your-user/#create-a-url-encoded-json-object-for-lt-claims-request-gt
+      userinfo_claims: [], # array of URLs; see https://docs.sign-in.service.gov.uk/integrate-with-integration-environment/authenticate-your-user/#create-a-url-encoded-json-object-for-lt-claims-request-gt
+     signing_algorithm: 'ES256', # The algorithm used to encode/decode the JWT token, RS256 also supported
     }
 
     # will call `Users::OmniauthController#failure` if there are any errors during the login process

--- a/lib/omniauth/govuk_one_login/backchannel_logout_utility.rb
+++ b/lib/omniauth/govuk_one_login/backchannel_logout_utility.rb
@@ -65,7 +65,7 @@ module OmniAuth
           @logout_token,
           @idp_configuration.public_keys,
           true,
-          algorithm: "ES256",
+          algorithm: %w[ES256 RS256],
           aud: @client_id,
           verify_aud: true,
           verify_iat: true,

--- a/lib/omniauth/govuk_one_login/client.rb
+++ b/lib/omniauth/govuk_one_login/client.rb
@@ -3,7 +3,7 @@ module OmniAuth
     class Client
       attr_reader :client_id, :idp_configuration, :private_key,
                   :redirect_uri, :private_key_kid, :scope,
-                  :ui_locales, :vtr, :pkce, :userinfo_claims
+                  :ui_locales, :vtr, :pkce, :userinfo_claims, :signing_algorithm
 
       def initialize(
         client_id:,
@@ -15,10 +15,11 @@ module OmniAuth
         ui_locales:,
         vtr:,
         pkce:,
-        userinfo_claims:
+        userinfo_claims:,
+        signing_algorithm:
       )
         @client_id = client_id
-        @idp_configuration = IdpConfiguration.new(idp_base_url: idp_base_url)
+        @idp_configuration = IdpConfiguration.new(idp_base_url: idp_base_url, signing_algorithm:)
         @private_key = private_key
         @redirect_uri = redirect_uri
         @private_key_kid = private_key_kid
@@ -27,6 +28,7 @@ module OmniAuth
         @vtr = vtr
         @pkce = pkce
         @userinfo_claims = userinfo_claims
+        @signing_algorithm = signing_algorithm
       end
     end
   end

--- a/lib/omniauth/govuk_one_login/id_token.rb
+++ b/lib/omniauth/govuk_one_login/id_token.rb
@@ -33,7 +33,7 @@ module OmniAuth
           id_token,
           client.idp_configuration.public_keys,
           true,
-          algorithm: "ES256",
+          algorithm: client.signing_algorithm,
           aud: client.client_id,
           verify_aud: true,
           verify_iat: true,

--- a/lib/omniauth/govuk_one_login/idp_configuration.rb
+++ b/lib/omniauth/govuk_one_login/idp_configuration.rb
@@ -1,10 +1,12 @@
 module OmniAuth
   module GovukOneLogin
     class IdpConfiguration
-      attr_reader :idp_base_url
+      attr_reader :idp_base_url, :signing_algorithm
 
-      def initialize(idp_base_url:)
+
+      def initialize(idp_base_url:, signing_algorithm: "ES256")
         @idp_base_url = idp_base_url
+        @signing_algorithm = signing_algorithm
       end
 
       def authorization_endpoint
@@ -27,7 +29,7 @@ module OmniAuth
         @public_keys = begin
           keys = JSON.parse(jwks_endpoint_response.body)["keys"]
           jwks = JWT::JWK::Set.new(keys)
-          jwks.filter! { |key| key[:use] == "sig" && key[:alg] == "ES256" }
+          jwks.filter! { |key| key[:use] == "sig" && key[:alg] == signing_algorithm }
           jwks.map(&:public_key)
         end
       end

--- a/lib/omniauth/govuk_one_login/version.rb
+++ b/lib/omniauth/govuk_one_login/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module GovukOneLogin
-    VERSION = "1.5.0".freeze
+    VERSION = "1.5.1".freeze
   end
 end

--- a/lib/omniauth/strategies/govuk_one_login.rb
+++ b/lib/omniauth/strategies/govuk_one_login.rb
@@ -13,6 +13,7 @@ module OmniAuth
       option :vtr, ["Cl.Cm"]
       option :pkce, false
       option :userinfo_claims, []
+      option :signing_algorithm, "ES256"
 
       attr_reader :authorization, :callback
 
@@ -66,7 +67,8 @@ module OmniAuth
           ui_locales: options.ui_locales,
           vtr: options.vtr,
           pkce: options.pkce,
-          userinfo_claims: options.userinfo_claims
+          userinfo_claims: options.userinfo_claims,
+          signing_algorithm: options.signing_algorithm
         )
       end
     end

--- a/spec/omniauth/govuk_one_login/backchannel_logout_utility_spec.rb
+++ b/spec/omniauth/govuk_one_login/backchannel_logout_utility_spec.rb
@@ -18,10 +18,12 @@ describe OmniAuth::GovukOneLogin::BackchannelLogoutUtility do
         sub: jwt_sub,
         events: jwt_events_claim
       },
-      IdpFixtures.private_keys.first,
-      "ES256"
+      private_key,
+      signing_algorithm
     )
   end
+  let(:private_key) { IdpFixtures.private_keys.first }
+  let(:signing_algorithm) { "ES256" }
 
   subject do
     described_class.new(
@@ -32,8 +34,9 @@ describe OmniAuth::GovukOneLogin::BackchannelLogoutUtility do
 
   before do
     stub_openid_configuration_request
-    stub_jwks_request
+    stub_jwks_request(body:)
   end
+  let(:body) { default_jwks_response_body }
 
   describe "#get_sub!" do
     context "initialized with idp_base_url" do
@@ -66,15 +69,34 @@ describe OmniAuth::GovukOneLogin::BackchannelLogoutUtility do
     before { subject.send(:logout_token, jwt) }
 
     context "when all fields pass validation" do
-      it "returns the decoded logout token" do
-        expect(subject.send(:decoded_logout_token)).to include(
-          "aud" => jwt_aud,
-          "exp" => jwt_exp,
-          "iat" => jwt_iat,
-          "iss" => jwt_iss,
-          "sub" => jwt_sub,
-          "events" => jwt_events_claim
-        )
+      context "with ES256 algorithm" do
+        it "returns the decoded logout token" do
+          expect(subject.send(:decoded_logout_token)).to include(
+            "aud" => jwt_aud,
+            "exp" => jwt_exp,
+            "iat" => jwt_iat,
+            "iss" => jwt_iss,
+            "sub" => jwt_sub,
+            "events" => jwt_events_claim
+          )
+        end
+      end
+
+      context "with RS256 algorithm" do
+        let(:private_key) { IdpFixtures.rsa_256_private_keys.first }
+        let(:signing_algorithm) { "RS256" }
+        let(:body) { jwks_rs256_body }
+
+        it "returns the decoded logout token" do
+          expect(subject.send(:decoded_logout_token)).to include(
+            "aud" => jwt_aud,
+            "exp" => jwt_exp,
+            "iat" => jwt_iat,
+            "iss" => jwt_iss,
+            "sub" => jwt_sub,
+            "events" => jwt_events_claim
+          )
+        end
       end
     end
 

--- a/spec/omniauth/govuk_one_login/client_spec.rb
+++ b/spec/omniauth/govuk_one_login/client_spec.rb
@@ -2,7 +2,10 @@ describe OmniAuth::GovukOneLogin::Client do
   it "initializes" do
     idp_configuration = MockIdpConfiguration.new
     allow(OmniAuth::GovukOneLogin::IdpConfiguration).to receive(:new)
-      .with(idp_base_url: IdpFixtures.base_url)
+      .with(
+        idp_base_url: IdpFixtures.base_url,
+        signing_algorithm: IdpFixtures.signing_algorithm
+      )
       .and_return(idp_configuration)
 
     subject = described_class.new(
@@ -15,7 +18,8 @@ describe OmniAuth::GovukOneLogin::Client do
       ui_locales: "en",
       vtr: ["Cl.Cm"],
       pkce: true,
-      userinfo_claims: []
+      userinfo_claims: [],
+      signing_algorithm: "ES256"
     )
 
     expect(subject.client_id).to eq(ClientFixtures.client_id)
@@ -28,5 +32,6 @@ describe OmniAuth::GovukOneLogin::Client do
     expect(subject.vtr).to eq(["Cl.Cm"])
     expect(subject.pkce).to eq(true)
     expect(subject.userinfo_claims).to eq([])
+    expect(subject.signing_algorithm).to eq("ES256")
   end
 end

--- a/spec/omniauth/govuk_one_login/id_token_spec.rb
+++ b/spec/omniauth/govuk_one_login/id_token_spec.rb
@@ -20,20 +20,23 @@ describe OmniAuth::GovukOneLogin::IdToken do
         nonce: jwt_nonce,
         vot: jwt_vot
       },
-      IdpFixtures.private_keys.first,
-      "ES256"
+      private_key,
+      signing_algorithm
     )
   end
+  let(:private_key) { IdpFixtures.private_keys.first }
+  let(:signing_algorithm) { "ES256" }
 
   subject do
     OmniAuth::GovukOneLogin::IdToken.new(
-      client: MockClient.new,
+      client:,
       access_token: "super-sekret-token",
       id_token: jwt,
       expires_in: 900,
       token_type: "Bearer"
     )
   end
+  let(:client) { MockClient.new({ signing_algorithm: }) }
 
   describe "#verify_nonce" do
     context "when the nonce matches the nonce in the session" do
@@ -75,15 +78,41 @@ describe OmniAuth::GovukOneLogin::IdToken do
 
   describe "#decoded_id_token" do
     context "when all fields pass validation" do
-      it "returns the decoded ID token" do
-        expect(subject.send(:decoded_id_token)).to include(
-          "aud" => jwt_aud,
-          "exp" => jwt_exp,
-          "iat" => jwt_iat,
-          "iss" => jwt_iss,
-          "nonce" => jwt_nonce,
-          "vot" => jwt_vot
-        )
+      context "when signing_algorithm is ES256 " do
+        it "returns the decoded ID token" do
+          expect(subject.send(:decoded_id_token)).to include(
+            "aud" => jwt_aud,
+            "exp" => jwt_exp,
+            "iat" => jwt_iat,
+            "iss" => jwt_iss,
+            "nonce" => jwt_nonce,
+            "vot" => jwt_vot
+          )
+        end
+      end
+
+      context "when signing_algorithm is RS256 " do
+        let(:private_key) { IdpFixtures.rsa_256_private_keys.first }
+        let(:signing_algorithm) { "RS256" }
+        let(:client) do
+          MockClient.new(
+            {
+              signing_algorithm:,
+              idp_configuration: MockIdpConfiguration.new(signing_algorithm:)
+            }
+          )
+        end
+
+        it "returns the decoded ID token" do
+          expect(subject.send(:decoded_id_token)).to include(
+            "aud" => jwt_aud,
+            "exp" => jwt_exp,
+            "iat" => jwt_iat,
+            "iss" => jwt_iss,
+            "nonce" => jwt_nonce,
+            "vot" => jwt_vot
+          )
+        end
       end
     end
 

--- a/spec/omniauth/govuk_one_login/idp_configuration_spec.rb
+++ b/spec/omniauth/govuk_one_login/idp_configuration_spec.rb
@@ -49,6 +49,17 @@ describe OmniAuth::GovukOneLogin::IdpConfiguration do
       end
     end
 
+    context "when signing_algorithm is RS256" do
+      before { stub_jwks_request(body: jwks_rs256_body) }
+      subject { described_class.new(idp_base_url: IdpFixtures.base_url, signing_algorithm: "RS256") }
+
+      it "returns the IDP public keys" do
+        result = subject.public_keys
+
+        expect(result.map(&:to_pem)).to eq(IdpFixtures.rsa_256_public_keys.map(&:public_to_pem))
+      end
+    end
+
     context "when the certs request fails" do
       before { stub_jwks_request(body: "Not found", status: 404) }
 

--- a/spec/support/fixtures/idp_fixtures.rb
+++ b/spec/support/fixtures/idp_fixtures.rb
@@ -3,6 +3,17 @@ module IdpFixtures
     @private_keys ||= [OpenSSL::PKey::EC.generate("prime256v1"), OpenSSL::PKey::EC.generate("prime256v1")]
   end
 
+  def self.rsa_256_private_keys
+    @rsa_256_private_keys ||= [
+      OpenSSL::PKey::RSA.generate(2048),
+      OpenSSL::PKey::RSA.generate(2048)
+    ]
+  end
+
+  def self.rsa_256_public_keys
+    rsa_256_private_keys.map(&:public_key)
+  end
+
   def self.public_keys
     # `OpenSSL::PKey::EC` is different to other key types - we can use the root object
     private_keys
@@ -11,6 +22,12 @@ module IdpFixtures
   def self.public_key_jwks
     public_keys.map do |public_key|
       JWT::JWK.new(public_key, { use: "sig", alg: "ES256" }).export
+    end
+  end
+
+  def self.public_key_jwks_rs256
+    rsa_256_public_keys.map do |public_key|
+      JWT::JWK.new(public_key, { use: "sig", alg: "RS256" }).export
     end
   end
 
@@ -40,5 +57,9 @@ module IdpFixtures
 
   def self.end_session_endpoint
     "https://oidc.account.gov.uk/logout"
+  end
+
+  def self.signing_algorithm
+    "ES256"
   end
 end

--- a/spec/support/idp_webmocks/jwks_webmock.rb
+++ b/spec/support/idp_webmocks/jwks_webmock.rb
@@ -8,6 +8,10 @@ module JwksWebmock
     jwks_response_body(keys: IdpFixtures.public_key_jwks)
   end
 
+  def jwks_rs256_body
+    jwks_response_body(keys: IdpFixtures.public_key_jwks_rs256)
+  end
+
   def jwks_response_body(keys:)
     { keys: keys }.to_json
   end

--- a/spec/support/mock_client.rb
+++ b/spec/support/mock_client.rb
@@ -1,7 +1,8 @@
 class MockClient
   attr_reader :client_id, :idp_configuration, :private_key,
               :redirect_uri, :private_key_kid, :scope,
-              :ui_locales, :vtr, :pkce, :userinfo_claims
+              :ui_locales, :vtr, :pkce, :userinfo_claims,
+              :signing_algorithm
 
   def initialize(overrides = {})
     @client_id = ClientFixtures.client_id
@@ -14,6 +15,7 @@ class MockClient
     @vtr = ["Cl.Cm"]
     @pkce = true
     @userinfo_claims = []
+    @signing_algorithm = "ES256"
 
     overrides.each do |key, value|
       instance_variable_set("@#{key}", value)

--- a/spec/support/mock_idp_configuration.rb
+++ b/spec/support/mock_idp_configuration.rb
@@ -1,4 +1,10 @@
 class MockIdpConfiguration
+  attr_reader :signing_algorithm
+
+  def initialize(signing_algorithm: "ES256")
+    @signing_algorithm = signing_algorithm
+  end
+
   def idp_base_url
     IdpFixtures.base_url
   end
@@ -24,6 +30,10 @@ class MockIdpConfiguration
   end
 
   def public_keys
-    IdpFixtures.public_keys
+    if signing_algorithm == "ES256"
+      IdpFixtures.public_keys
+    else
+      IdpFixtures.rsa_256_public_keys
+    end
   end
 end


### PR DESCRIPTION
Applications that have a one login integration already in place in production. With a different signing algorithm to ES256(which is the default in this gem), cannot easily use this gem. 

One login production integrations cannot easily change signing algorithms. As this will require downtime.

So for services that use RS256 and cannot change their integration easily. This commit changes the gem to allow the client to configure the signing algorithm.

In essence we need changes in two places. When signing in. We need to use the signing algorithm that the client specified.

And also in the backchannel functionality. We need to allow both ES256 and RS256 to decode the token. As we don't have the client preference at that point.
